### PR TITLE
Update minigame to Minecraft 1.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,10 @@ dependencies {
     include "kdotjpg:open-simplex:2.0"
 
     // Plasmid
-    modImplementation "xyz.nucleoid:plasmid:0.5+1.18.1-SNAPSHOT"
+    modImplementation "xyz.nucleoid:plasmid:0.5+1.18.2-SNAPSHOT"
     modImplementation "xyz.nucleoid:substrate:0.1.1"
 
-    modRuntimeOnly ("supercoder79:databreaker:0.2.8") {
+    modRuntimeOnly ("supercoder79:databreaker:0.2.9") {
         exclude module : "fabric-loader"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.18.1
-yarn_mappings=1.18.1+build.22
-loader_version=0.12.12
+minecraft_version=1.18.2
+yarn_mappings=1.18.2+build.3
+loader_version=0.14.5
 # Mod Properties
 mod_version=0.1.0
 maven_group=supercoder79
 archives_base_name=rocketspleef
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.46.4+1.18
+fabric_version=0.51.1+1.18.2

--- a/src/main/java/supercoder79/rocketspleef/game/RsChunkGenerator.java
+++ b/src/main/java/supercoder79/rocketspleef/game/RsChunkGenerator.java
@@ -5,16 +5,15 @@ import net.minecraft.block.Blocks;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.noise.PerlinNoiseSampler;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.world.WorldAccess;
 import net.minecraft.world.biome.BiomeKeys;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.gen.StructureAccessor;
 import net.minecraft.world.gen.chunk.Blender;
-import net.minecraft.world.gen.chunk.StructuresConfig;
 import net.minecraft.world.gen.random.SimpleRandom;
 import xyz.nucleoid.plasmid.game.world.generator.GameChunkGenerator;
 
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
@@ -24,7 +23,7 @@ public class RsChunkGenerator extends GameChunkGenerator {
     private final PerlinNoiseSampler colorNoise;
 
     public RsChunkGenerator(MinecraftServer server) {
-        super(createBiomeSource(server, BiomeKeys.PLAINS), new StructuresConfig(Optional.empty(), Collections.emptyMap()));
+        super(server.getRegistryManager().get(Registry.STRUCTURE_SET_KEY), Optional.empty(), createBiomeSource(server, BiomeKeys.PLAINS));
         this.colorNoise = new PerlinNoiseSampler(new SimpleRandom(server.getOverworld().getSeed()));
     }
 
@@ -40,7 +39,7 @@ public class RsChunkGenerator extends GameChunkGenerator {
 
                     double progress = (y - 31) / 66.0;
 
-                    progress += this.colorNoise.sample(x / 8.0, y / 8.0, z / 8.0, 0, 0) * 0.05;
+                    progress += this.colorNoise.sample(x / 8.0, y / 8.0, z / 8.0) * 0.05;
 
                     Block glass;
                     if (progress < (1 / 6.0)) {


### PR DESCRIPTION
Due to NucleoidMC/stimuli#23, explosions will crash the game, but fixing that issue is outside of this pull request's scope.