### PR TITLE
Fix game mode changes not being sent to clients

### DIFF
--- a/src/main/java/supercoder79/rocketspleef/game/RsActive.java
+++ b/src/main/java/supercoder79/rocketspleef/game/RsActive.java
@@ -220,10 +220,10 @@ public class RsActive {
         RsWaiting.resetPlayer(player, GameMode.SPECTATOR);
         player.teleport(player.getServerWorld(), 0, 66, 0, 0.0F, 0.0F);
 
-        long remaining = this.space.getPlayers().stream().filter(p -> p.interactionManager.getGameMode().isSurvivalLike()).count();
+        long remaining = this.space.getPlayers().stream().filter(p -> p.interactionManager.isSurvivalLike()).count();
         if (remaining <= 1) {
             if (remaining == 1) {
-                ServerPlayerEntity lastPlayer = this.space.getPlayers().stream().filter(p -> p.interactionManager.getGameMode().isSurvivalLike()).findFirst().orElse(null);
+                ServerPlayerEntity lastPlayer = this.space.getPlayers().stream().filter(p -> p.interactionManager.isSurvivalLike()).findFirst().orElse(null);
                 if (lastPlayer != null) {
                     this.space.getPlayers().sendMessage(Text.translatable("text.rocket_spleef.player_won", lastPlayer.getEntityName()).formatted(Formatting.GOLD));
                 }

--- a/src/main/java/supercoder79/rocketspleef/game/RsWaiting.java
+++ b/src/main/java/supercoder79/rocketspleef/game/RsWaiting.java
@@ -86,7 +86,7 @@ public final class RsWaiting {
         player.getHungerManager().setFoodLevel(20);
         player.getHungerManager().add(5, 0.5F);
         player.fallDistance = 0.0F;
-        player.interactionManager.changeGameMode(mode);
+        player.changeGameMode(mode);
         player.setExperienceLevel(0);
         player.setExperiencePoints(0);
     }


### PR DESCRIPTION
This pull request fixes an issue where players would visually appear to be in survival mode after being eliminated, despite being in spectator mode on the server.

Relates to NucleoidMC/survival-games#18